### PR TITLE
Allow line-breaks in tweets

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -401,6 +401,7 @@ main .tweet-desk .tweet .head .dots {
 main .tweet-desk .tweet .content .message {
   padding-top: 16px;
   font-size: 23px;
+  white-space: pre-wrap;
 }
 main .tweet-desk .tweet .content .message .highlight {
   color: #1b95e0;


### PR DESCRIPTION
By default, line-breaks in the tweet body are ignored:  
![capture](https://user-images.githubusercontent.com/2776014/157729281-10a7ff2c-204a-4195-b380-a40778c654de.png)

However, setting `white-space: pre-wrap` fixes this:  
![capture](https://user-images.githubusercontent.com/2776014/157728153-5a53a16f-a50c-49ec-bb8d-334afe1df2ea.png)